### PR TITLE
feat: added express doc generation

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,7 +8,6 @@
 
 <script>
 import Navbar from "~/components/shared/Navbar"
-//import CustomNav from "~/components/shared/CustomNav"
 import Footer from "~/components/shared/Footer"
 export default {
   components: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,24 +1,45 @@
-import redirectSSL from 'redirect-ssl'
+import redirectSSL from "redirect-ssl";
 export default {
   // Disable server-side rendering (https://go.nuxtjs.dev/ssr-mode)
   //mode: "universal",
 
   // Global page headers (https://go.nuxtjs.dev/config-head)
   head: {
-    title: 'Open Network | Knowledge Endpoint',
+    title: "Open Network | Knowledge Endpoint",
     meta: [
       { charset: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1" },
-      { hid: "description", name: "description", content: process.env.npm_package_description },
-      { hid: "og:title", name: "og:title", content: 'Open Network | Knowledge Endpoint' },
-      { hid: "og:url", name: "og:url", content: process.env.BASE_URL || 'http://localhost:300' },
-      { hid: "og:description", name: "og:description", content: process.env.npm_package_description },
-      { hid: "og:image", name: "og:image", content: 'https://opntwk-project-images.s3-eu-west-1.amazonaws.com/meta_image.png' },
+      {
+        hid: "description",
+        name: "description",
+        content: process.env.npm_package_description
+      },
+      {
+        hid: "og:title",
+        name: "og:title",
+        content: "Open Network | Knowledge Endpoint"
+      },
+      {
+        hid: "og:url",
+        name: "og:url",
+        content: process.env.BASE_URL || "http://localhost:300"
+      },
+      {
+        hid: "og:description",
+        name: "og:description",
+        content: process.env.npm_package_description
+      },
+      {
+        hid: "og:image",
+        name: "og:image",
+        content:
+          "https://opntwk-project-images.s3-eu-west-1.amazonaws.com/meta_image.png"
+      }
     ],
     link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }],
     script: [
       {
-        src: 'https://kit.fontawesome.com/6f67b3e9f1.js'
+        src: "https://kit.fontawesome.com/6f67b3e9f1.js"
       }
     ]
   },
@@ -28,14 +49,14 @@ export default {
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [
-    { src: '~/plugins/vuelidate' },
-    { src: '~/plugins/filters' },
-    { src: '~/plugins/integrations' },
-    { src: '~/plugins/tooltip' },
-    { src: '~/plugins/toasted', ssr: false },
-    { src: '~/plugins/paginate', ssr: false },
-    { src: '~/plugins/form_wizard' },
-    { src: '~/plugins/vue-instantsearch' }
+    { src: "~/plugins/vuelidate" },
+    { src: "~/plugins/filters" },
+    { src: "~/plugins/integrations" },
+    { src: "~/plugins/tooltip" },
+    { src: "~/plugins/toasted", ssr: false },
+    { src: "~/plugins/paginate", ssr: false },
+    { src: "~/plugins/form_wizard" },
+    { src: "~/plugins/vue-instantsearch" }
   ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
@@ -71,16 +92,20 @@ export default {
    * Axios module configuration
    */
   axios: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000'
+    baseURL: process.env.BASE_URL || "http://localhost:3000"
   },
 
   // Server Middleware
-  serverMiddleware: ["~/server/routes/index.js", redirectSSL.create({
-    enabled: process.env.NODE_ENV === 'production'
-  }),],
+  serverMiddleware: [
+    "~/server/routes/index.js",
+    redirectSSL.create({
+      enabled: process.env.NODE_ENV === "production"
+    }),
+    { path: "/", handle: "~/server/routes/swagger.js" }
+  ],
 
   // Build Configuration (https://go.nuxtjs.dev/config-build)
   build: {
-    transpile: ['vue-instantsearch', 'instantsearch.js/es'],
+    transpile: ["vue-instantsearch", "instantsearch.js/es"]
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5437,6 +5437,11 @@
         "get-intrinsic": "^1.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -7288,6 +7293,22 @@
         }
       }
     },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "doctrine-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/doctrine-file/-/doctrine-file-1.0.3.tgz",
+      "integrity": "sha512-OK37HbZtNmIMn84riibVXRmcEGUIf6BNfYMcbXg20ejP+LEsf4tnk8QfYy3EmQs4KzZFhTl3zwoKqVwARxpBgA==",
+      "requires": {
+        "doctrine": "^2.0.0"
+      }
+    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -8004,6 +8025,27 @@
         }
       }
     },
+    "express-swagger-generator": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/express-swagger-generator/-/express-swagger-generator-1.1.17.tgz",
+      "integrity": "sha512-eKB2cR3TcvmSepkqjm9sFPqPAV7PQawyc3Df2p9/0vN4Q7LyBrLLpechH246YYJ1kIDPa8RresfhJeIHg5zS4A==",
+      "requires": {
+        "doctrine": "^2.0.0",
+        "doctrine-file": "^1.0.2",
+        "express-swaggerize-ui": "^1.0.3",
+        "glob": "^7.0.3",
+        "recursive-iterator": "^2.0.3",
+        "swagger-parser": "^5.0.5"
+      }
+    },
+    "express-swaggerize-ui": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/express-swaggerize-ui/-/express-swaggerize-ui-1.1.0.tgz",
+      "integrity": "sha512-dDJuWV/GlISNYyKvFMa3EDr6sYzMgMrVRCt9o1kQxaIIKnmK1NJvaTzGbRIokIlGGHriIT6E2ztorRyRxLuOzA==",
+      "requires": {
+        "express": "^4.13.3"
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -8442,6 +8484,11 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+    },
+    "format-util": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.5.tgz",
+      "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
     "formidable": {
       "version": "1.2.2",
@@ -11838,6 +11885,17 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-ref-parser": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz",
+      "integrity": "sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "js-yaml": "^3.12.0",
+        "ono": "^4.0.6"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -11871,6 +11929,16 @@
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         }
       }
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+    },
+    "jsonschema-draft4": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
+      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -12242,6 +12310,11 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -12251,6 +12324,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -14019,6 +14097,14 @@
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
       "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
     },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "requires": {
+        "format-util": "^1.0.3"
+      }
+    },
     "open": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/open/-/open-7.3.1.tgz",
@@ -14026,6 +14112,16 @@
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
+      }
+    },
+    "openapi-schema-validation": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
+      "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
+      "requires": {
+        "jsonschema": "1.2.4",
+        "jsonschema-draft4": "^1.0.0",
+        "swagger-schema-official": "2.0.0-bab6bed"
       }
     },
     "opener": {
@@ -19382,6 +19478,11 @@
         "picomatch": "^2.2.1"
       }
     },
+    "recursive-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/recursive-iterator/-/recursive-iterator-2.0.3.tgz",
+      "integrity": "sha1-0ODSx+eoMQnXMJHPBD/FCeWnbcM="
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -21350,6 +21451,31 @@
         }
       }
     },
+    "swagger-methods": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
+      "integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
+    },
+    "swagger-parser": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-5.0.6.tgz",
+      "integrity": "sha512-FdzCYFK11iGgrOpojlqUluU6SKThtzmu+5Get+6ValJR2TFwTnES1x4Fdfgy3C4/8VVXk4Va/WsqGlbyY/Os+A==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "json-schema-ref-parser": "^5.1.3",
+        "ono": "^4.0.6",
+        "openapi-schema-validation": "^0.4.2",
+        "swagger-methods": "^1.0.4",
+        "swagger-schema-official": "2.0.0-bab6bed",
+        "z-schema": "^3.23.0"
+      }
+    },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -22427,6 +22553,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -23848,6 +23979,31 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "z-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
+      "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
+      "requires": {
+        "commander": "^2.7.1",
+        "core-js": "^2.5.7",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^10.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "optional": true
+        },
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express": "^4.17.1",
     "express-formidable": "^1.2.0",
     "express-session": "^1.17.1",
+    "express-swagger-generator": "^1.1.17",
     "formidable": "^1.2.2",
     "gridfs-stream": "^1.1.1",
     "highlight.js": "^10.5.0",

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -1,6 +1,4 @@
 
-const passport = require('passport')
-
 exports.onlyAuthUser = function (req, res, next) {
   if (req.isAuthenticated()) {
     return next()

--- a/server/controllers/blog.js
+++ b/server/controllers/blog.js
@@ -1,24 +1,7 @@
 const Blog = require("../models/blog");
 const slugify = require("slugify");
-const request = require("request");
 const AsyncLock = require("async-lock");
 const lock = new AsyncLock();
-
-const MEDIUM_URL = "https://medium.com/@any/latest?format=json&limit=20";
-
-// function parseFilters(queries) {
-//   const parsedQueries = {};
-//   if (queries.filter) {
-//     Object.keys(queries).forEach(qKey => {
-//       if (qKey.includes("filter")) {
-//         const pKey = qKey.match(/\[([^)]+)\]/)[1];
-//         parsedQueries[pKey] = queries[qKey];
-//       }
-//     });
-//   }
-
-//   return parsedQueries;
-// }
 
 exports.getBlogs = (req, res) => {
   const pageSize = parseInt(req.query.pageSize) || 0;
@@ -44,18 +27,6 @@ exports.getBlogs = (req, res) => {
       });
     });
 };
-
-// exports.getMediumBlogs = (req, res) => {
-//   request.get(MEDIUM_URL, (err, apiRes, body) => {
-//     if (!err && apiRes.statusCode === 200) {
-//       let i = body.indexOf("{");
-//       const data = body.substr(i);
-//       res.send(data);
-//     } else {
-//       res.sendStatus(500).json(err);
-//     }
-//   });
-// };
 
 exports.getBlogBySlug = (req, res) => {
   const slug = req.params.slug;

--- a/server/index.js
+++ b/server/index.js
@@ -1,32 +1,33 @@
-const express = require('express')
-const consola = require('consola')
-const { Nuxt, Builder } = require('nuxt')
-const app = express()
+const express = require("express");
+const consola = require("consola");
+const { Nuxt, Builder } = require("nuxt");
+const app = express();
 
-const config = require('../nuxt.config.js')
-config.dev = !(process.env.NODE_ENV === 'production')
+const config = require("../nuxt.config.js");
+config.dev = !(process.env.NODE_ENV === "production");
 
 async function start() {
   // Init Nuxt.js
-  const nuxt = new Nuxt(config)
-  const { host, port } = nuxt.options.server
+  const nuxt = new Nuxt(config);
+  const { host, port } = nuxt.options.server;
 
   // Build only in dev mode
   if (config.dev) {
-    const builder = new Builder(nuxt)
-    await builder.build()
+    const builder = new Builder(nuxt);
+    await builder.build();
   } else {
-    await nuxt.ready()
+    await nuxt.ready();
   }
 
   // Give nuxt middleware to express
-  app.use(nuxt.render)
+  app.use(nuxt.render);
 
   // Listen the server
-  app.listen(port, host)
+  app.listen(port, host);
   consola.ready({
     message: `Server listening on http://${host}:${port}`,
     badge: true
-  })
+  });
+
 }
-start()
+start();

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1,8 +1,4 @@
 const express = require('express');
 const router = express.Router();
 
-const ApiCtrl = require('../controllers/api');
-
-//router.get('', ApiCtrl.getPageData);
-
 module.exports = router;

--- a/server/routes/blog.js
+++ b/server/routes/blog.js
@@ -6,33 +6,63 @@ const AuthCtrl = require("../controllers/auth");
 
 router.get("", blogCtrl.getBlogs);
 
-//router.get("/medium", blogCtrl.getMediumBlogs);
+/**
+ * Allow to get blogs creater by the current logged user
+ * @route GET /blogs/me
+ * @group blogs - Operations about blogs
+ * @returns {Array.<object>} 200 - An array of blogs created by the current user
+ * @returns {Error} 422 - Error found
+ */
+router.get("/me", AuthCtrl.onlyAuthUser, blogCtrl.getUserBlogs);
 
-router.get(
-  "/me",
-  AuthCtrl.onlyAuthUser,
-  //AuthCtrl.onlyAdmin,
-  blogCtrl.getUserBlogs
-);
-
+/**
+ * Allow to get blogs by id
+ * @route GET /blogs/:id
+ * @param {string} id - Blog id
+ * @group blogs - Operations about blogs
+ * @returns {object} 200 - The blog by ID
+ * @returns {Error} 422 - Error found
+ */
 router.get("/:id", blogCtrl.getBlogById);
 
+/**
+ * Allow to get blogs by slug
+ * @route GET /blogs/s/:slug
+ * @param {string} slug - Blog slug
+ * @group blogs - Operations about blogs
+ * @returns {Array<object>} 200 - An array of blogs created by the current user
+ * @returns {Error} 422 - Error found
+ */
 router.get("/s/:slug", blogCtrl.getBlogBySlug);
 
-router.post("", AuthCtrl.onlyAuthUser, /* AuthCtrl.onlyAdmin, */ blogCtrl.createBlog);
+/**
+ * Allow to create a blog
+ * @route POST /blogs
+ * @param {object} blog - The blog to add
+ * @group blogs - Operations about blogs
+ * @returns {object} 200 - Return the blog created
+ * @returns {Error} 422 - Error found
+ */
+router.post("", AuthCtrl.onlyAuthUser, blogCtrl.createBlog);
 
-router.patch(
-  "/:id",
-  AuthCtrl.onlyAuthUser,
-  //AuthCtrl.onlyAdmin,
-  blogCtrl.updateBlog
-);
+/**
+ * Allow to update a blog
+ * @route PATCH /blogs
+ * @param {object} blog - The blog to update
+ * @group blogs - Operations about blogs
+ * @returns {object} 200 - Return the blog created
+ * @returns {Error} 422 - Error found
+ */
+router.patch("/:id", AuthCtrl.onlyAuthUser, blogCtrl.updateBlog);
 
-router.delete(
-  "/:id",
-  AuthCtrl.onlyAuthUser,
-  //AuthCtrl.onlyAdmin,
-  blogCtrl.deleteBlog
-);
+/**
+ * Allow to delete a blog
+ * @route DELETE /blogs
+ * @param {object} blog - The blog to update
+ * @group blogs - Operations about blogs
+ * @returns {object} 200 - Return the blog created
+ * @returns {Error} 422 - Error found
+ */
+router.delete("/:id", AuthCtrl.onlyAuthUser, blogCtrl.deleteBlog);
 
 module.exports = router;

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -3,6 +3,13 @@ const router = express.Router();
 
 const CategoriesCtrl = require('../controllers/category');
 
+/**
+ * Allow to get all categories
+ * @route GET /categories
+ * @group categories - Operations about categories
+ * @returns {Array<object>} 200 - An array of categories 
+ * @returns {Error} 422 - Error found
+ */
 router.get('', CategoriesCtrl.getCategories);
 
 module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,8 +2,6 @@ const express = require("express");
 const app = express();
 const session = require("express-session");
 const db = require("../db");
-const algolia = require("../algolia");
-const path = require("path");
 
 const bodyParser = require("body-parser");
 const keys = require("../keys");
@@ -15,7 +13,6 @@ const productRoutes = require("./product");
 const categoryRoutes = require("./category");
 const blogRoutes = require("./blog");
 const apiRoutes = require("./api");
-const formidable = require('express-formidable')
 
 require("../services/passport");
 
@@ -23,8 +20,6 @@ require("../services/passport");
 db.connect();
 
 const store = db.initSessionStore();
-
-//algolia.initSyncWithAlgolia();
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -56,6 +51,7 @@ app.use("/users", usersRoutes);
 app.use("/products", productRoutes);
 app.use("/categories", categoryRoutes);
 app.use("/blogs", blogRoutes);
+
 
 module.exports = {
   path: "/api/v1",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,6 +2,7 @@ const express = require("express");
 const app = express();
 const session = require("express-session");
 const db = require("../db");
+const algolia = require("../algolia");
 
 const bodyParser = require("body-parser");
 const keys = require("../keys");
@@ -16,10 +17,10 @@ const apiRoutes = require("./api");
 
 require("../services/passport");
 
-// connect to DB
 db.connect();
 
 const store = db.initSessionStore();
+algolia.initSyncWithAlgolia();
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));

--- a/server/routes/product.js
+++ b/server/routes/product.js
@@ -6,22 +6,72 @@ const ProductCtrl = require("../controllers/product.js");
 const upload = require("../controllers/upload");
 const singleUpload = upload.single("image");
 
+/**
+ * Allow to get all products
+ * @route GET /products
+ * @group products - Operations about products
+ * @returns {Array<object>} 200 - An array of products 
+ * @returns {Error} 422 - Error found
+ */
 router.get("", ProductCtrl.getProducts);
+
+/**
+ * Allow to get all products of the users
+ * @route GET /products/user-products
+ * @group products - Operations about products
+ * @returns {Array<object>} 200 - An array of products of the user
+ * @returns {Error} 422 - Error found
+ */
 router.get(
   "/user-products",
   AuthCtrl.onlyAuthUser,
-  //AuthCtrl.onlyAdmin,
   ProductCtrl.getInstructorProducts
 );
+
+/**
+ * Allow to get a product by id
+ * @route GET /products/:id
+ * @group products - Operations about products
+ * @param {string} id - The id of the product
+ * @returns {object} 200 - The product queried with id
+ * @returns {Error} 422 - Error found
+ */
 router.get("/:id", ProductCtrl.getProductById);
+
+/**
+ * Allow to get a product by slug
+ * @route GET /products/s/:slug
+ * @group products - Operations about products
+ * @param {string} slug - The slug of the product
+ * @returns {object} 200 - The product queried with slug
+ * @returns {Error} 422 - Error found
+ */
 router.get("/s/:slug", ProductCtrl.getProductBySlug);
 
+/**
+ * Allow to create a product
+ * @route POST /products
+ * @group products - Operations about products
+ * @param {string} product - The slug of the product
+ * @returns {object} 200 - The product created
+ * @returns {Error} 422 - Error found
+ */
 router.post(
   "",
   AuthCtrl.onlyAuthUser,
   //AuthCtrl.onlyAdmin,
   ProductCtrl.createProduct
 );
+
+/**
+ * Allow to add an image to a product
+ * @route POST /products/:id/add-project-image
+ * @group products - Operations about products
+ * @param {string} id - The id of the product
+ * @param {object} image - The image in the body
+ * @returns {object} 200 - Return the product updated with image
+ * @returns {Error} 400 - Image upload error
+ */
 router.post("/:id/add-project-image", function(req, res) {
   const uid = req.params.id;
 
@@ -42,10 +92,18 @@ router.post("/:id/add-project-image", function(req, res) {
       .catch(error => res.status(400).json({ success: false, error: error }));
   });
 });
+
+/**
+ * Allow to update a product
+ * @route POST /products
+ * @group products - Operations about products
+ * @param {object} product - The product in the body
+ * @returns {object} 200 - Return the product updated
+ * @returns {Error} 422 - Error found
+ */
 router.patch(
   "/:id",
   AuthCtrl.onlyAuthUser,
-  //AuthCtrl.onlyAdmin,
   ProductCtrl.updateProduct
 );
 

--- a/server/routes/swagger.js
+++ b/server/routes/swagger.js
@@ -1,0 +1,38 @@
+const express = require("express");
+const app = express();
+
+const expressSwagger = require('express-swagger-generator')(app);
+
+let options = {
+    swaggerDefinition: {
+        info: {
+            description: 'The API documentation of Open network',
+            title: 'Open network API docs',
+            version: '1.0.0',
+        },
+        host: 'localhost:3000',
+        basePath: '/api/v1',
+        produces: [
+            "application/json",
+            "application/xml"
+        ],
+        schemes: ['http', 'https'],
+		securityDefinitions: {
+            JWT: {
+                type: 'apiKey',
+                in: 'header',
+                name: 'Authorization',
+                description: "",
+            }
+        }
+    },
+    basedir: __dirname, //app absolute path
+    files: ['./*.js'] //Path to the API handle folder
+};
+
+expressSwagger(options)
+
+module.exports = {
+  path: "/",
+  handler: app
+};

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -4,15 +4,84 @@ const router = express.Router();
 const UsersCtrl = require('../controllers/user');
 const AuthCtrl = require('../controllers/auth');
 
+/**
+ * Allow to get the current user
+ * @route GET /users/me
+ * @group users - Operations about users
+ * @returns {object} 200 - Return the user
+ * @returns {Error} 422 - Error found
+ */
 router.get('/me', AuthCtrl.onlyAuthUser, UsersCtrl.getCurrentUser);
 
+/**
+ * Allow to register a user
+ * @route POST /users/register
+ * @group users - Operations about users
+ * @param {object} user - User credentials with login and password
+ * @returns {object} 201 - Return the user created
+ * @returns {Error} 422 - Error found
+ */
 router.post('/register', UsersCtrl.register)
+
+/**
+ * Allow to login a user
+ * @route POST /users/login
+ * @group users - Operations about users
+ * @param {object} user - User credentials with login and password
+ * @returns {object} 200 - Return the session created with passport
+ * @returns {Error} 422 - Error found
+ */
 router.post('/login', UsersCtrl.login)
+
+/**
+ * Allow to disconnect a user
+ * @route POST /users/logout
+ * @group users - Operations about users
+ * @returns {string} 200 - Destroy the session by invalidating JWT 
+ * @returns {Error} 422 - Error found
+ */
 router.post('/logout', UsersCtrl.logout)
+
+/**
+ * Allow to ask a password reset
+ * @route POST /users/forgot
+ * @group users - Operations about users
+ * @param {object} user - User credentials with only email
+ * @returns {string} 200 - Success and sending an email to the user
+ * @returns {Error} 422 - Error found
+ */
 router.post('/forgot', UsersCtrl.forgotPassword)
+
+/**
+ * Allow to enter a code to reset password
+ * @route POST /users/resetPwd/:token
+ * @group users - Operations about users
+ * @param {string} token - Token sent by email to the user
+ * @returns {string} 200 - Password modified
+ * @returns {Error} 422 - Password is not the same as confirmation password
+ * @returns {Error} 500 - Server error
+ */
 router.post('/resetPwd/:token', UsersCtrl.resetPassword)
+
+/**
+ * Allow to send a confirmation email
+ * @route POST /users/send-confirmation-email
+ * @group users - Operations about users
+ * @param {object} user - User credentials with only email
+ * @returns {string} 200 - Confirmation email has been sent
+ * @returns {Error} 400 - Confirmation email has not been sent
+ */
 router.post('/send-confirmation-email', UsersCtrl.sendConfirmationEmail)
 
+/**
+ * Allow to send a confirmation email
+ * @route POST /users/confirm/:token*
+ * @group users - Operations about users
+ * @param {string} token - Token to confirm email
+ * @returns {string} 200 - Your email adress is confirmed
+ * @returns {Error} 400 - The token is invalid or expired
+ * @returns {Error} 500 - Server error
+ */
 router.get('/confirm/:token*', UsersCtrl.confirmEmail)
 
 module.exports = router;

--- a/store/index.js
+++ b/store/index.js
@@ -8,7 +8,7 @@ export const actions = {
   async nuxtServerInit({ commit, dispatch }) {
     // Called on server before page is rendered
     await dispatch("auth/getAuthUser").catch(_ =>
-      console.log("Not Authenticatd!")
+      console.log("Not Authenticated!")
     );
   }
 };


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #47   <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

![image](https://user-images.githubusercontent.com/21025565/105196965-712ef400-5b3c-11eb-827a-254455942b6c.png)

I added JSDoc on different express endpoints. A middleware called **express-swagger-generator** take care to generate a swagger  endpoint that can be queried when accessing the URL-OF-THE-SERVER/api-docs url.

## What problem is this fixing?

A lack of documentation for different routes
